### PR TITLE
Review the use of thread local

### DIFF
--- a/build/libplumber.cmake
+++ b/build/libplumber.cmake
@@ -6,11 +6,11 @@ set(local_cflags ${CFLAGS})
 find_package(OpenSSL)
 set_source_files_properties(${src_files} PROPERTIES COMPILE_FLAGS "${CFLAGS} -I${OPENSSL_INCLUDE_DIR}")
 
-if("${STATIC}" STREQUAL "yes")
-	add_library(plumber ${src_files})
-else("${STATIC}" STREQUAL "yes")
+if("${SHARED_LIBPLUMBER}" STREQUAL "yes")
 	add_library(plumber SHARED ${src_files})
-endif("${STATIC}" STREQUAL "yes")
+else("${SHARED_LIBPLUMBER}" STREQUAL "yes")
+	add_library(plumber ${src_files})
+endif("${SHARED_LIBPLUMBER}" STREQUAL "yes")
 
 target_link_libraries(plumber ${OPENSSL_LIBRARIES} ${GLOBAL_LIBS} proto)
 

--- a/build/misc.cmake
+++ b/build/misc.cmake
@@ -34,11 +34,12 @@ add_custom_target(uninstall
 	COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 
 add_custom_target(show-flags
-	COMMAND echo "Compiler = ${CMAKE_C_COMPILER}" && 
-	        echo "Log Level = ${LOG}" &&
-			echo "Optimaization = ${OPTLEVEL}" &&
+	COMMAND echo "Compiler       = ${CMAKE_C_COMPILER}" && 
+	        echo "Log Level      = ${LOG}" &&
+			echo "Optimaization  = ${OPTLEVEL}" &&
 			echo "Compiler Flags = ${CFLAGS}" &&
-			echo "Static Library = ${STATIC}" &&
+			echo "Linker Flags   = ${LIBS}" &&
+			echo "Shared Libplumber = ${SHARED_LIBPLUMBER}" &&
 			echo "Config CommandLine: $ENV{CFLAGS} CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} cmake -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DPLUMBER_V8_PREFIX=${PLUMBER_V8_PREFIX} -DLOG=${LOG} -DOPTLEVEL=${OPTLEVEL} ${package_status} ${option_status} ${CMAKE_SOURCE_DIR}" )	
 
 add_custom_target(book

--- a/build/setup.cmake
+++ b/build/setup.cmake
@@ -54,7 +54,12 @@ endif(NOT "$ENV{CXX}" STREQUAL "")
 message("Compiler: ${CMAKE_C_COMPILER}")
 message("Log Level: ${LOG}")
 message("Optimization Level: ${OPTLEVEL}")
+
 set(CFLAGS $ENV{CFLAGS}\ -O${OPTLEVEL}\ -Wconversion\ -Wextra\ -Wall\ -Werror\ -g)
+
+if("${OPTLEVEL}" STREQUAL "3")
+	set(CFLAGS ${CFLAGS}\ -DFULL_OPTIMIZATION)
+endif("${OPTLEVEL}" STREQUAL "3")
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/${INCLUDE_DIR}" 
 	                "${CMAKE_CURRENT_BINARY_DIR}")

--- a/build/setup.cmake
+++ b/build/setup.cmake
@@ -55,11 +55,13 @@ message("Compiler: ${CMAKE_C_COMPILER}")
 message("Log Level: ${LOG}")
 message("Optimization Level: ${OPTLEVEL}")
 
-set(CFLAGS $ENV{CFLAGS}\ -O${OPTLEVEL}\ -Wconversion\ -Wextra\ -Wall\ -Werror\ -g)
+if("${OPTLEVEL}" GREATER "3")
+	set(OPT_CFLAGS "-DFULL_OPTIMIZATION -DSTACK_SIZE=0x200000")
+	set(OPTLEVEL 3)
+	message("FYI: you are configuring the project into a full optimization mode, which will enable some unsafe optimization")
+endif("${OPTLEVEL}" GREATER "3")
 
-if("${OPTLEVEL}" STREQUAL "3")
-	set(CFLAGS ${CFLAGS}\ -DFULL_OPTIMIZATION\ -DSTACK_SIZE=0x200000)
-endif("${OPTLEVEL}" STREQUAL "3")
+set(CFLAGS "$ENV{CFLAGS} -O${OPTLEVEL} ${OPT_CFLAGS} -Wconversion -Wextra -Wall -Werror -g")
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/${INCLUDE_DIR}" 
 	                "${CMAKE_CURRENT_BINARY_DIR}")

--- a/build/setup.cmake
+++ b/build/setup.cmake
@@ -58,7 +58,7 @@ message("Optimization Level: ${OPTLEVEL}")
 set(CFLAGS $ENV{CFLAGS}\ -O${OPTLEVEL}\ -Wconversion\ -Wextra\ -Wall\ -Werror\ -g)
 
 if("${OPTLEVEL}" STREQUAL "3")
-	set(CFLAGS ${CFLAGS}\ -DFULL_OPTIMIZATION)
+	set(CFLAGS ${CFLAGS}\ -DFULL_OPTIMIZATION\ -DSTACK_SIZE=0x200000)
 endif("${OPTLEVEL}" STREQUAL "3")
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/${INCLUDE_DIR}" 

--- a/examples/greeting/main.c
+++ b/examples/greeting/main.c
@@ -96,14 +96,18 @@ int main(int argc, char** argv)
 	itc_module_type_t mod_tcp = itc_modtab_get_module_type_from_path("pipe.tcp.port_8888");
 	itc_module_type_t mem_pipe = itc_modtab_get_module_type_from_path("pipe.mem");
 
+	sched_task_context_t* stc = sched_task_context_new();
+
 	for(;!_stopped;)
 	{
 		itc_module_pipe_t *in, *out;
 		itc_module_pipe_accept(mod_tcp, request_param, &in, &out);
-		sched_task_new_request(service, in, out);
+		sched_task_new_request(stc, service, in, out);
 
-		while(sched_step_next(mem_pipe) > 0);
+		while(sched_step_next(stc, mem_pipe) > 0);
 	}
+
+	sched_task_context_free(stc);
 
 	return 0;
 }

--- a/include/runtime/task.h
+++ b/include/runtime/task.h
@@ -83,6 +83,17 @@ runtime_task_t* runtime_task_new(runtime_servlet_t* servlet, runtime_task_flags_
 int runtime_task_start(runtime_task_t* task);
 
 /**
+ * @brief This is the fast version to start an exec task
+ * @details This function is dangerous, because it won't do param check and will assume
+ *          The task is exec task. In addition, it do not recover the current task variable
+ *          This function is completely for performance purpose, because most of the task
+ *          are exec task and we should have a way to do it faster
+ * @param task The task to start
+ * @return status code
+ **/
+int runtime_task_start_exec_fast(runtime_task_t* task);
+
+/**
  * @brief get current task
  * @return the task object of current task, NULL if there's an error
  **/

--- a/include/sched/step.h
+++ b/include/sched/step.h
@@ -16,12 +16,13 @@
 /**
  * @brief take the next step
  * @param type the pipe type between nodes
+ * @param stc the scheduler task context for current thread
  * @return status code <br/>
  *         0 nothing to do <br/>
  *         negative for error case <br/>
  *         otherwise take one step
  **/
-int sched_step_next(itc_module_type_t type);
+int sched_step_next(sched_task_context_t* stc, itc_module_type_t type);
 
 /**
  * @brief get the current request scope object

--- a/include/sched/task.h
+++ b/include/sched/task.h
@@ -13,7 +13,13 @@
 #define __PLUMBER_SCHED_TASK_H__
 
 /**
- * @brief The scheduler task context 
+ * @brief The scheduler task context (STC)
+ * @note  This is the scheduler's task context, for each scheduler thread we have
+ *        a isolated scheduler task context, which include a task table, a read
+ *        task queue and metadata. <br/>
+ *        Before we introduces this, the context is implemented by a group of thread
+ *        locals, however, the performance penalty is so high. So that we introduced
+ *        this context
  **/
 typedef struct _sched_task_context_t sched_task_context_t;
 
@@ -96,7 +102,6 @@ sched_task_t* sched_task_next_ready_task(sched_task_context_t* ctx);
 /**
  * @brief dispose a task that is already launched
  * @param task the task to dispose
- * @param ctx The scheduler task context
  * @return status code
  **/
 int sched_task_free(sched_task_t* task);
@@ -104,7 +109,6 @@ int sched_task_free(sched_task_t* task);
 /**
  * @brief notify that this task has a pipe gets ready
  * @param task the task to notify
- * @param ctx The scheduler task context
  * @return status code
  **/
 int sched_task_pipe_ready(sched_task_t* task);
@@ -116,7 +120,6 @@ int sched_task_pipe_ready(sched_task_t* task);
  * @param task the target task
  * @param pipe the target pipe id
  * @param handle the pipe handle to set
- * @param ctx The scheduler task context
  * @return status code
  **/
 int sched_task_output_pipe(sched_task_t* task, runtime_api_pipe_id_t pipe, itc_module_pipe_t* handle);
@@ -131,7 +134,6 @@ int sched_task_output_pipe(sched_task_t* task, runtime_api_pipe_id_t pipe, itc_m
  * @param task the target task
  * @param pipe the target pipe id
  * @param handle the pipe handle
- * @param ctx The scheduler task context
  * @return status code
  **/
 int sched_task_output_shadow(sched_task_t* task, runtime_api_pipe_id_t pipe, itc_module_pipe_t* handle);
@@ -141,7 +143,6 @@ int sched_task_output_shadow(sched_task_t* task, runtime_api_pipe_id_t pipe, itc
  *        be cancelled and all the downstream pipes are cancelled
  * @note  this does not change the ready state, so another pipe_ready call is reuiqred to get the task in ready state
  * @param task the target task
- * @param ctx The scheduler task context
  * @return status code
  **/
 int sched_task_input_cancelled(sched_task_t* task);

--- a/include/utils/thread.h
+++ b/include/utils/thread.h
@@ -46,7 +46,19 @@ typedef enum {
 typedef struct _thread_t thread_t;
 
 /**
- * @brief The test main function
+ * @brief The main function used for the testing envionment
+ * @note This function should only used for testing purpose <br/>
+ *       Because when we enabled the aligned stack by specifying the size of
+ *       the stack, we will be able to use a simple integer arithmetic to figure out
+ *       the thread id, which is light-weight. <br/>
+ *       However, the price we have to pay for doing this, is that the main thread is
+ *       an exception and if you called the get_thread_id then you will be in trouble.<br/>
+ *       This is not a big issue in libplumber code, since the main thread is converted
+ *       to dispatcher thread and do not use any thread utilities at all. <br/>
+ *       However, in the test cases, there's a lot of example of calling the thread related
+ *       utils from the main thread, which causes crash. <br/>
+ *       To address this, we have to make the main function for the test cases using an aligned
+ *       stack. And this is the way for us to initialize a thread with aligned stack at this point
  **/
 typedef int (*thread_test_main_t)();
 
@@ -192,9 +204,11 @@ thread_type_t thread_get_current_type();
 const char* thread_type_name(thread_type_t type, char* buf, size_t size);
 
 /**
- * @brief Run the test main function
+ * @brief Run the main function for testing, for more information see the 
+ *        documentation for thread_test_main_t
+ * @param main the testing main function 
  * @return exit code
- * @note this function do not require initalization
+ * @note This function does not require the entire system initialized
  **/
 int thread_run_test_main(thread_test_main_t main);
 #endif

--- a/include/utils/thread.h
+++ b/include/utils/thread.h
@@ -197,5 +197,4 @@ const char* thread_type_name(thread_type_t type, char* buf, size_t size);
  * @note this function do not require initalization
  **/
 int thread_run_test_main(thread_test_main_t main);
-
 #endif

--- a/include/utils/thread.h
+++ b/include/utils/thread.h
@@ -46,6 +46,11 @@ typedef enum {
 typedef struct _thread_t thread_t;
 
 /**
+ * @brief The test main function
+ **/
+typedef int (*thread_test_main_t)();
+
+/**
  * @brief the function type for the main function of a thread
  * @param data the user-defined data
  * @return the result
@@ -185,5 +190,12 @@ thread_type_t thread_get_current_type();
  * @note the output format should be [type1,type2,type3]...
  **/
 const char* thread_type_name(thread_type_t type, char* buf, size_t size);
+
+/**
+ * @brief Run the test main function
+ * @return exit code
+ * @note this function do not require initalization
+ **/
+int thread_run_test_main(thread_test_main_t main);
 
 #endif

--- a/lib/pstd/build.cmake
+++ b/lib/pstd/build.cmake
@@ -1,6 +1,6 @@
 set(TYPE shared-library)
 set(LOCAL_CFLAGS "-fPIC")
-set(LOCAL_LIBS plumber pservlet)
+set(LOCAL_LIBS pservlet)
 set(LOCAL_SOURCE types)
 set(INSTALL "yes")
 install_includes("${SOURCE_PATH}/include" "include/pstd" "*.h")

--- a/src/module/pssm/module.c
+++ b/src/module/pssm/module.c
@@ -17,13 +17,22 @@
 #include <utils/thread.h>
 #include <utils/static_assertion.h>
 
-#include <error.h>
-#include <runtime/api.h>
 #include <itc/module_types.h>
 #include <itc/module.h>
-#include <module/pssm/module.h>
+
+#include <error.h>
+#include <runtime/api.h>
+#include <runtime/pdt.h>
+#include <runtime/servlet.h>
+#include <runtime/task.h>
+#include <runtime/stab.h>
+
+#include <sched/service.h>
 #include <sched/rscope.h>
+#include <sched/task.h>
 #include <sched/step.h>
+
+#include <module/pssm/module.h>
 
 /**
  * @brief the actual data strcuture for an allocated memory chucnk

--- a/src/runtime/task.c
+++ b/src/runtime/task.c
@@ -119,6 +119,19 @@ runtime_task_t* runtime_task_new(runtime_servlet_t* servlet, runtime_task_flags_
 	return ret;
 
 }
+
+int runtime_task_start_exec_fast(runtime_task_t* task)
+{
+	LOG_TRACE("%s Task (TID = %d) started", task->servlet->bin->name, task->id);
+
+	_current_task = task;
+
+	if(NULL != task->servlet->bin->define->exec)
+		return task->servlet->bin->define->exec(task->servlet->data);
+
+	return 0;
+}
+
 int runtime_task_start(runtime_task_t *task)
 {
 	if(NULL == task)

--- a/src/sched/step.c
+++ b/src/sched/step.c
@@ -96,7 +96,7 @@ int sched_step_next(sched_task_context_t* stc, itc_module_type_t type)
 #ifdef FULL_OPTIMIZATION
 	if(runtime_task_start_exec_fast(task->exec_task) == ERROR_CODE(int))
 #else
-	if(runtime_task_start_exec(task->exec_task) == ERROR_CODE(int))
+	if(runtime_task_start(task->exec_task) == ERROR_CODE(int))
 #endif
 	{
 #ifdef ENABLE_PROFILER

--- a/src/sched/step.c
+++ b/src/sched/step.c
@@ -108,7 +108,6 @@ int sched_step_next(sched_task_context_t* stc, itc_module_type_t type)
 #ifdef ENABLE_PROFILER
 	if(sched_service_profiler_timer_stop(task->service) == ERROR_CODE(int))
 	    LOG_WARNING("Cannot stop the profiler");
-	_current_request_scope = NULL;
 	if(counter > 10000)
 	{
 		sched_service_profiler_flush(task->service);

--- a/src/sched/task.c
+++ b/src/sched/task.c
@@ -408,7 +408,7 @@ int sched_task_finalize()
  * @param claim indicates if we needs claim the onwership of the pipe
  * @return status code
  **/
-static inline int _task_add_pipe( _task_entry_t* task, runtime_api_pipe_id_t pipe, itc_module_pipe_t* handle, int claim)
+static inline int _task_add_pipe(_task_entry_t* task, runtime_api_pipe_id_t pipe, itc_module_pipe_t* handle, int claim)
 {
 	if(NULL == task || NULL == handle || pipe == ERROR_CODE(runtime_api_pipe_id_t)) ERROR_RETURN_LOG(int, "Invalid arguments");
 

--- a/src/sched/task.c
+++ b/src/sched/task.c
@@ -678,7 +678,8 @@ sched_task_t* sched_task_next_ready_task(sched_task_context_t* ctx)
 int sched_task_free(sched_task_t* task)
 {
 	int rc = 0;
-	_request_entry_t* req = _request_entry_find(task->ctx, task->request);
+	sched_task_context_t* ctx = task->ctx;
+	_request_entry_t* req = _request_entry_find(ctx, task->request);
 	if(NULL == req) rc = ERROR_CODE(int);
 
 	if(NULL != task->exec_task)
@@ -690,7 +691,7 @@ int sched_task_free(sched_task_t* task)
 	if(NULL != req && 0 == --req->num_pending_tasks)
 	{
 		LOG_DEBUG("Request %"PRIu64" is done", req->request_id);
-		if(ERROR_CODE(int) == _request_entry_delete(task->ctx, req->request_id))
+		if(ERROR_CODE(int) == _request_entry_delete(ctx, req->request_id))
 		    rc = ERROR_CODE(int);
 	}
 

--- a/src/sched/task.c
+++ b/src/sched/task.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <errno.h>
 
+#include <predict.h>
 #include <error.h>
 #include <plumber.h>
 

--- a/src/utils/mempool/objpool.c
+++ b/src/utils/mempool/objpool.c
@@ -282,7 +282,7 @@ int mempool_objpool_free(mempool_objpool_t* pool)
  * @param tlp the thread local pool we want to store the result
  * @return the number of objects that has been allocated, or error code
  **/
-static inline uint32_t _global_alloc(mempool_objpool_t* pool, _thread_local_pool_t* tlp)
+__attribute__((noinline)) static uint32_t _global_alloc(mempool_objpool_t* pool, _thread_local_pool_t* tlp)
 {
 	uint32_t ret = ERROR_CODE(uint32_t);
 
@@ -380,8 +380,11 @@ void* mempool_objpool_alloc(mempool_objpool_t* pool, int fill_zero)
 
 	/* First try to get the object from the local pool */
 	_thread_local_pool_t* tlp = thread_pset_acquire(pool->local_pool);
+
+#ifdef FULL_OPTIMIZATION
 	if(PREDICT_FALSE(NULL == tlp))
 	    ERROR_PTR_RETURN_LOG("Cannot acquire the thread local pool for current thread TID=%u", thread_get_id());
+#endif
 
 	if(PREDICT_FALSE(tlp->count == 0))
 	{

--- a/src/utils/mempool/objpool.c
+++ b/src/utils/mempool/objpool.c
@@ -367,7 +367,9 @@ RET:
 
 void* mempool_objpool_alloc(mempool_objpool_t* pool, int fill_zero)
 {
+#ifdef FULL_OPTIMIZATION
 	if(PREDICT_FALSE(NULL == pool)) ERROR_PTR_RETURN_LOG("Invalid arguments");
+#endif
 	if(PREDICT_FALSE(_is_pool_disabled(pool)))
 	{
 		if(fill_zero) return calloc(1, pool->obj_size);
@@ -437,8 +439,10 @@ static inline int _global_dealloc(mempool_objpool_t* pool, _cached_object_t* beg
 
 int mempool_objpool_dealloc(mempool_objpool_t* pool, void* mem)
 {
+#ifdef FULL_OPTIMIZATION
 	if(PREDICT_FALSE(NULL == pool || NULL == mem))
 	    ERROR_RETURN_LOG(int, "Invalid arguments");
+#endif
 
 	if(PREDICT_FALSE(_is_pool_disabled(pool)))
 	{

--- a/src/utils/thread.c
+++ b/src/utils/thread.c
@@ -288,9 +288,10 @@ int thread_pset_free(thread_pset_t* pset)
 
 void* thread_pset_acquire(thread_pset_t* pset)
 {
+#ifndef FULL_OPTIMIZATION
 	if(PREDICT_FALSE(NULL == pset))
 	    ERROR_PTR_RETURN_LOG("Invalid arguments");
-
+#endif
 	return _get_current_pointer(pset);
 }
 

--- a/src/utils/thread.c
+++ b/src/utils/thread.c
@@ -92,7 +92,7 @@ static __thread thread_t* _thread_obj = NULL;
  **/
 static inline uint32_t _get_thread_id()
 {
-	if(_thread_id == ERROR_CODE(uint32_t))
+	if(PREDICT_FALSE(_thread_id == ERROR_CODE(uint32_t)))
 	{
 		uint32_t claimed_id;
 		do {

--- a/test/module/test_pssm.c
+++ b/test/module/test_pssm.c
@@ -5,6 +5,8 @@
 #include <pthread.h>
 #include <module/builtins.h>
 
+#include <utils/thread.h>
+
 runtime_stab_entry_t mem_pool_sid;
 runtime_stab_entry_t thread_local_test_sid;
 int thread_local_test_ok;
@@ -46,12 +48,12 @@ void* test_thread(void* data)
 
 int test_thread_local()
 {
-	pthread_t thread[32];
+	thread_t* thread[32];
 	int i;
 	for(i = 0; i < 32; i ++)
-	    pthread_create(thread + i, NULL, test_thread, NULL);
+		ASSERT_PTR(thread[i] = thread_new(test_thread, NULL, THREAD_TYPE_GENERIC), CLEANUP_NOP);
 	for(i = 0; i < 32; i ++)
-	    pthread_join(thread[i], NULL);
+		ASSERT_OK(thread_free(thread[i], NULL), CLEANUP_NOP);
 
 	ASSERT_OK(thread_local_test_ok, CLEANUP_NOP);
 

--- a/test/utils/test_thread.c
+++ b/test/utils/test_thread.c
@@ -3,10 +3,9 @@
  **/
 #include <testenv.h>
 #include <utils/thread.h>
-#include <pthread.h>
 #define N 128
-uint32_t data[N];
-uint32_t data2[N];
+uint32_t data[N * 2];
+uint32_t data2[N * 2];
 
 thread_pset_t* pset1, *pset2;
 
@@ -68,27 +67,30 @@ static inline void* thread_main(void* ptr)
 }
 int run()
 {
-	pthread_t t[N];
+	thread_t* t[N];
 	uint32_t i;
 	for(i = 0; i < N; i ++)
-	    ASSERT_OK(pthread_create(t + i, NULL, thread_main, NULL), CLEANUP_NOP);
+	    ASSERT_PTR(t[i] = thread_new(thread_main, NULL, THREAD_TYPE_GENERIC), CLEANUP_NOP);
 
 	for(i = 0; i < N; i ++)
 	{
 		void* ret;
-		ASSERT_OK(pthread_join(t[i], &ret), CLEANUP_NOP);
+		ASSERT_OK(thread_free(t[i], &ret), CLEANUP_NOP);
 		ASSERT_PTR(ret, CLEANUP_NOP);
 	}
 	return 0;
 }
 int dispose()
 {
-	uint32_t i;
-	for(i = 0; i < N; i ++)
-	    ASSERT(data[i] == 10, CLEANUP_NOP);
+	uint32_t i, j = 0;
+	for(i = 0; i < 2 * N; i ++)
+		if(data[i] == 10) j ++;
+	ASSERT(j == N, CLEANUP_NOP);
 
-	for(i = 0; i < N; i ++)
-	    ASSERT(data2[i] == 20, CLEANUP_NOP);
+	j = 0;
+	for(i = 0; i < 2 * N; i ++)
+		if(data[i] == 10) j ++;
+	ASSERT(j == N, CLEANUP_NOP);
 
 	ASSERT_OK(thread_pset_free(pset1), CLEANUP_NOP);
 	ASSERT_OK(thread_pset_free(pset2), CLEANUP_NOP);


### PR DESCRIPTION
Currently we use too many thread locals
For this change, we implemented a faster version of runtime_task_start
for exec task (which is the most common one)

For the scheduler task table, instead of using thread local, we
introduce the (STC, which stands for scheduler task context) to
eliminate the thread local used in the table