### PR TITLE
Add header files for the new virtual node API in service buffer

### DIFF
--- a/include/sched/service.h
+++ b/include/sched/service.h
@@ -20,6 +20,19 @@ typedef struct _sched_cnode_info_t sched_cnode_info_t;
 typedef uint32_t sched_service_node_id_t;
 
 /**
+ * @brief Indicates this node is a virtual node, which is made up by 
+ *        connecting different node into a service buffer
+ **/
+#define SCHED_SERVICE_VNODE_MASK (0x80000000u)
+
+/**
+ * @brief Check if current node id stands for a virtual node
+ * @param node the node ID
+ * @return If the node is a virtual node
+ **/
+#define SCHED_SERVICE_IS_VNODE(node) ((ndoe)&SCHED_SERVICE_IS_VNODE)
+
+/**
  * @brief define a service
  **/
 typedef struct _sched_service_t sched_service_t;
@@ -73,6 +86,15 @@ int sched_service_buffer_allow_reuse_servlet(sched_service_buffer_t* buffer);
  * @return the node ID or negative error code
  **/
 sched_service_node_id_t sched_service_buffer_add_node(sched_service_buffer_t* buffer, runtime_stab_entry_t sid);
+
+/**
+ * @brief Add a new virtual node which is a reference to another service buffer
+ * @note  Service buffer can also be used as a logic node which is actually serveral different connected node
+ * @param buffer the service buffer to connect
+ * @param vnode the virtual node
+ * @return The node id, the node ID should be the ID that is used for virtual node only 
+ **/
+sched_service_node_id_t sched_service_buffer_add_virtual_node(sched_service_buffer_t* buffer, const sched_service_buffer_t* vnode);
 
 /**
  * @brief add a pipe between two nodes

--- a/include/sched/service.h
+++ b/include/sched/service.h
@@ -108,6 +108,14 @@ sched_service_node_id_t sched_service_buffer_add_virtual_node(sched_service_buff
 runtime_api_pipe_id_t sched_service_buffer_add_named_port(sched_service_buffer_t* buffer, const char* name, int is_input, sched_service_node_id_t nid, runtime_api_pipe_id_t pid);
 
 /**
+ * @brief Get the name of the virtual node port from the pipe id
+ * @param buffer The target service buffer
+ * @param pipe   The pipe ID
+ * @return The name of the port, NULL if there's any error
+ **/
+const char* sched_service_buffer_get_port_name(const sched_service_buffer_t* buffer, runtime_api_pipe_id_t pipe);
+
+/**
  * @brief add a pipe between two nodes
  * @param buffer the target service buffer
  * @param desc the pipe

--- a/include/sched/service.h
+++ b/include/sched/service.h
@@ -97,6 +97,17 @@ sched_service_node_id_t sched_service_buffer_add_node(sched_service_buffer_t* bu
 sched_service_node_id_t sched_service_buffer_add_virtual_node(sched_service_buffer_t* buffer, const sched_service_buffer_t* vnode);
 
 /**
+ * @brief Add a named input for the service buffer, this is used when the service buffer is using as a virtual node
+ * @param buffer The service buffer we want to set the virtual named input
+ * @param name The name of the service
+ * @param is_input Indicates if this virtual named port is a input node
+ * @param nid The node id 
+ * @param pid The pipe id, which should be a input pipe
+ * @return A pipe id which used to identify which virtual named input we are talking about, ERROR_CODE possible
+ **/
+runtime_api_pipe_id_t sched_service_buffer_add_named_port(sched_service_buffer_t* buffer, const char* name, int is_input, sched_service_node_id_t nid, runtime_api_pipe_id_t pid);
+
+/**
  * @brief add a pipe between two nodes
  * @param buffer the target service buffer
  * @param desc the pipe

--- a/src/lang/vm.c
+++ b/src/lang/vm.c
@@ -416,6 +416,7 @@ ERR:
  **/
 static inline int _service_add_node(lang_vm_t* vm, uint32_t service_reg, uint32_t target_reg, uint32_t name_reg, uint32_t args_reg, uint32_t graphviz_reg)
 {
+	/* TODO: we need handle the virtual node case */
 	if(target_reg >= vm->num_reg)
 	    ERROR_RETURN_LOG(int, "Invalid target register");
 
@@ -638,8 +639,9 @@ CLEANUP:
  * @param pipe_reg the register for the pipe register
  * @return status code
  **/
-static inline int _service_input_output(lang_vm_t* vm, int out, uint32_t serv_reg, uint32_t node_reg, uint32_t pipe_reg)
+static inline int _service_input_output(lang_vm_t* vm, int out, uint32_t serv_reg, uint32_t node_reg, uint32_t pipe_reg, uint32_t name_reg)
 {
+	(void)name_reg;  /* TODO: setup named ports */
 	_GET_PARAM(SERVICE, serv);
 	lang_vm_service_t* service = serv_val->data.service;
 	if(service->initialized)
@@ -1583,11 +1585,13 @@ static inline int _exec_invoke(lang_vm_t* vm, uint32_t pc)
 		        ERROR_RETURN_LOG(int, "Cannot add a node");
 		    break;
 		case LANG_BYTECODE_BUILTIN_INPUT:
-		    if(ERROR_CODE(int) == _service_input_output(vm, 0, _get_param(vm, 0), _get_param(vm, 1), _get_param(vm, 2)))
+		    if(ERROR_CODE(int) == _service_input_output(vm, 0, _get_param(vm, 0), _get_param(vm, 1), _get_param(vm, 2), 
+						                                vector_length(vm->params) > 3 ? _get_param(vm, 3) : ERROR_CODE(uint32_t)))
 		        ERROR_RETURN_LOG(int, "Cannot set input");
 		    break;
 		case LANG_BYTECODE_BUILTIN_OUTPUT:
-		    if(ERROR_CODE(int) == _service_input_output(vm, 1, _get_param(vm, 0), _get_param(vm, 1), _get_param(vm, 2)))
+		    if(ERROR_CODE(int) == _service_input_output(vm, 1, _get_param(vm, 0), _get_param(vm, 1), _get_param(vm, 2),
+						                                vector_length(vm->params) > 3 ? _get_param(vm, 3) : ERROR_CODE(uint32_t)))
 		        ERROR_RETURN_LOG(int, "Cannot set output");
 		    break;
 		case LANG_BYTECODE_BUILTIN_GRAPHVIZ:


### PR DESCRIPTION
We need to support the virtual node, which is actually a sub-graph which named inputs and outpus. 

The basic syntax are shared with service graph

```
       vnode = {
               node := "actual_node";
               another_vnode := vnode2;
               
               ("in") -> node "out" -> "in" another_vnode -> ("out")
       }
```
The only difference is we  use ("name") as the named input and output pipe.

We are planning to make the service buffer support this, because we want to resuse the service graph parser for this purpose. In this case, the only thing that needs to be change from the language side is:

1. Add syntax for declare a sub graph as a service node
2. Add named input/output syntax, which should be very similar to the real input and output
3. We need to get the service buffer's named ports for vistualization purpose
4. When we create a service from service buffer, we need to expand the virtual node to the actual node it stands for. (So we may need an hash table to avoid recursion)
...