### PR TITLE
Multithreaded TCP module

### DIFF
--- a/include/module/tcp/pool.h
+++ b/include/module/tcp/pool.h
@@ -73,6 +73,15 @@ typedef struct {
 module_tcp_pool_t* module_tcp_pool_new();
 
 /**
+ * @brief Fork an existing TCP pool. 
+ * @details This will create another connection pool listening to the same TCP port.
+ *          This is used when the event loop becomes a bottelneck, thus we want to 
+ *          use multiple event loop for the same socket FD
+ * @return the newly created connection pool object, or NULL on error
+ **/
+module_tcp_pool_t* module_tcp_pool_fork(module_tcp_pool_t* pool);
+
+/**
  * @brief dispose the used TCP connection pool
  * @param pool the connection pool to dispose
  * @return status code

--- a/include/module/tcp/pool.h
+++ b/include/module/tcp/pool.h
@@ -82,11 +82,11 @@ module_tcp_pool_t* module_tcp_pool_new();
 module_tcp_pool_t* module_tcp_pool_fork(module_tcp_pool_t* pool);
 
 /**
- * @brief Get how many slaves has been created under this master pool, 0 if the pool itself is a slave
+ * @brief Get how many forks has been created under this master pool, 0 if the pool itself is a forked pool
  * @param pool The pool to examine
- * @return The number of slaves or error code
+ * @return The number of forks or error code
  **/
-int module_tcp_pool_num_slaves(const module_tcp_pool_t* pool);
+int module_tcp_pool_num_forks(const module_tcp_pool_t* pool);
 
 /**
  * @brief dispose the used TCP connection pool

--- a/include/module/tcp/pool.h
+++ b/include/module/tcp/pool.h
@@ -82,6 +82,13 @@ module_tcp_pool_t* module_tcp_pool_new();
 module_tcp_pool_t* module_tcp_pool_fork(module_tcp_pool_t* pool);
 
 /**
+ * @brief Get how many slaves has been created under this master pool, 0 if the pool itself is a slave
+ * @param pool The pool to examine
+ * @return The number of slaves or error code
+ **/
+int module_tcp_pool_num_slaves(const module_tcp_pool_t* pool);
+
+/**
  * @brief dispose the used TCP connection pool
  * @param pool the connection pool to dispose
  * @return status code

--- a/src/module/tcp/module.c
+++ b/src/module/tcp/module.c
@@ -1319,6 +1319,13 @@ static itc_module_property_value_t _get_prop(void* __restrict ctx, const char* s
 
 		return ret;
 	}
+	else if(strcmp(sym, "nthreads") == 0)
+	{
+		if(context->port_id == 0) 
+			return _make_num((long long)module_tcp_pool_num_slaves(context->conn_pool));
+		else
+			return _make_num((long long)0);
+	}
 
 	return ret;
 }

--- a/src/module/tcp/module.c
+++ b/src/module/tcp/module.c
@@ -533,7 +533,7 @@ static inline int _init_connection_pool(_module_context_t* __restrict context)
 static inline int _module_context_init(_module_context_t* ctx, _module_context_t* master)
 {
 	if(master != NULL &&  master->port_id != 0)
-		ERROR_RETURN_LOG(int, "Invalid arguments: Trying start multithreaded eventloop on a slave?");
+		ERROR_RETURN_LOG(int, "Invalid arguments: Trying start multithreaded event loop on a forked module?");
 
 	if(_instance_count == 0)
 	{
@@ -565,7 +565,7 @@ static inline int _module_context_init(_module_context_t* ctx, _module_context_t
 	}
 	else 
 	{
-		if(ERROR_CODE(int) == (ctx->port_id = module_tcp_pool_num_slaves(master->conn_pool)))
+		if(ERROR_CODE(int) == (ctx->port_id = module_tcp_pool_num_forks(master->conn_pool)))
 			ERROR_RETURN_LOG(int, "Cannot get new port ID");
 
 		ctx->port_id ++;
@@ -1322,7 +1322,7 @@ static itc_module_property_value_t _get_prop(void* __restrict ctx, const char* s
 	else if(strcmp(sym, "nthreads") == 0)
 	{
 		if(context->port_id == 0) 
-			return _make_num((long long)module_tcp_pool_num_slaves(context->conn_pool));
+			return _make_num((long long)module_tcp_pool_num_forks(context->conn_pool));
 		else
 			return _make_num((long long)0);
 	}

--- a/src/module/tcp/module.c
+++ b/src/module/tcp/module.c
@@ -573,6 +573,8 @@ static inline int _module_context_init(_module_context_t* ctx, _module_context_t
 		if(NULL == (ctx->conn_pool = module_tcp_pool_fork(master->conn_pool)))
 			ERROR_RETURN_LOG(int, "Cannot fork TCP connection pool");
 
+		ctx->pool_conf.port = master->pool_conf.port;
+
 	}
 
 	_instance_count ++;
@@ -1372,7 +1374,10 @@ int module_tcp_module_set_port(void* ctx, uint16_t port)
 static const char* _get_path(void* __restrict ctx, char* buf, size_t sz)
 {
 	_module_context_t* context = (_module_context_t*)ctx;
-	snprintf(buf, sz, "port_%u", context->pool_conf.port);
+	if(context->port_id == 0)
+		snprintf(buf, sz, "port_%u", context->pool_conf.port);
+	else
+		snprintf(buf, sz, "port_%u$%d", context->pool_conf.port, context->port_id);
 	return buf;
 }
 

--- a/src/module/tcp/pool.c
+++ b/src/module/tcp/pool.c
@@ -300,7 +300,7 @@ int module_tcp_pool_free(module_tcp_pool_t* pool)
 
 	int rc = _finalize_conn_info(pool);
 
-	if(pool->socket_fd >= 0) close(pool->socket_fd);
+	if(pool->socket_fd >= 0 && pool->master == NULL) close(pool->socket_fd);
 
 	if(pool->event_fd >= 0) close(pool->event_fd);
 
@@ -382,6 +382,7 @@ static inline int _init_socket(module_tcp_pool_t* pool)
 			pool->saddr6 = pool->master->saddr6;
 		else
 			pool->saddr = pool->master->saddr;
+		pool->socket_fd = pool->master->socket_fd;
 	}
 
 	os_event_desc_t event = {
@@ -399,7 +400,7 @@ static inline int _init_socket(module_tcp_pool_t* pool)
 	LOG_DEBUG("TCP Socket has been initialized on %s:%"PRIu16, pool->conf.bind_addr, pool->conf.port);
 	return 0;
 ERR:
-	if(pool->socket_fd >= 0) close(pool->socket_fd);
+	if(pool->socket_fd >= 0 && pool->master == NULL) close(pool->socket_fd);
 	pool->socket_fd = ERROR_CODE(int);
 	return ERROR_CODE(int);
 }


### PR DESCRIPTION
Since we have the TCP event loop bottleneck when scheduler.worker.nthreads > 8. 
So we should make a TCP port can have multiple event loop on that.