### PR TITLE
Add spec for the operation that needed by direct buffer access

### DIFF
--- a/include/runtime/api.h
+++ b/include/runtime/api.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2017, Hao Hou
+ * Copyright (C) 2017-2018, Hao Hou
  **/
 
 /**
@@ -220,6 +220,71 @@ STATIC_ASSERTION_EQ_ID(flags_persist, RUNTIME_API_PIPE_PERSIST, (RUNTIME_API_PIP
  *        this function will return the path string of the module the pipe is using
  **/
 #define RUNTIME_API_PIPE_CNTL_OPCODE_MODPATH   0xff000009u
+
+/**
+ * @brief Get the header buffer directly from the underlying module
+ * @note  This function is similar to mmap in UNIX operating system. It actually
+ *        returns a memory address that contains expected data (which can be the
+ *        internal buffer or mmapped memory) directly. In this way, we are able 
+ *        to avoid the memcpy during the time of reading. But this makes the pipe
+ *        can not dispose the buffer until the pipe handle is completed disposed. 
+ *        Since once we expose the address of internal buffer to the application
+ *        space code, the buffer needs to be accessible during the entire life 
+ *        time of the handle. 
+ *        example: pipe_cntl(pipe, PIPE_CNTL_GET_HDR_BUF, nbytes, &hdr_buf);
+ *
+ *        It's possible that the header isn't carried completely by a continous memory
+ *        region, in this case, the invocation might result empty. In this situation,
+ *        the caller should use READHDR operation instead.
+ *
+ *        Note: there's no guareentee that the call will successfully pull out the buffer.
+ *              It may fail for no reason or simplely because the module doesn't support 
+ *              this inerface, or even because the header is too large for a continuous
+ *              memor region. In any case, we should have READHDR as "backup plan".
+ *
+ *        The hdr_buf = NULL indicates that we don't successfully pull out the expected buffer.
+ *        Otherwise the returned buffer should contain at least nbytes of data to consume.
+ *
+ *        In this case, the handle's read pointer will be moved forward. 
+ **/
+#define RUNTIME_API_PIPE_CNTL_OPCODE_GET_HDR_BUF 0xff00000au
+
+/**
+ * @brief Get the data body buffer directly from the underlying module
+ * @note  example: pipe_cntl(pipe, PIPE_CNLT_GET_DATA_BUF, required, &buffer, &upper_bound, &lower_bound);
+ *        This function is similar to mmap in UNIX, which directly returns the memory region
+ *        that contains the expected data. This call also doesn't guareentee successfully pulled
+ *        out. And once we did this the exposed internal buffer should not be disposed until the
+ *        pipe handle is dead. 
+ *        Since it's possible that the handle actually have no idea about when this request body 
+ *        ends (For example a HTTP request, or a line based text file). Thus we can not always 
+ *        get the correct data length. Instead it returns the upper bound of the availble size.
+ *        Thus, accessing the memory beyond the boundary should be definitely an error.
+ *
+ *        When the module doesn't know how long the region is the lower_bould will be 0, otherwise
+ *        the upper_bound and lower_bound are the same. 
+ *
+ *        At anytime the memory region will be at most required bytes in size.
+ *
+ *        Once the module returns the internal buffer that have undetermined size, any other read 
+ *        operation (including the get data buf operation) will return 0, until the end of the 
+ *        memory region has been determined by the applicatoin code by PUT_DATA_BUF cntl operation
+ **/
+#define RUNTIME_API_PIPE_CNTL_OPCODE_GET_DATA_BUF 0xff00000bu
+
+/**
+ * @brief Release the data body buffer which we get from get_data_buf
+ * @note  example: pipe_cntl(pipe, PIPE_CNLT_PUT_DATA_BUF, buffer, size)
+ *        This will inform the module about the actual size of the data that contains in the
+ *        memory region. This is useful when we are dealing with line based text file.
+ *        Since the buffer may contains the data from other lines, thus we can not determine
+ *        the end point of the buffer. This give us a chance to inform the end of the data 
+ *        for this request in buffer without actuall scanning it.
+ *
+ *        This indicates the handle is currently has an undermined memory region result has
+ *        been pulled out by the application layer code. Otherwise the call will be ignored
+ **/
+#define RUNTIME_API_PIPE_CNTL_OPCODE_PUT_DATA_BUF 0xff00000cu
 
 /**
  * @brief the pipe cntl opcode that indicates no operation

--- a/lib/pservlet/include/pservlet/pipe.h
+++ b/lib/pservlet/include/pservlet/pipe.h
@@ -136,11 +136,10 @@ size_t pipe_hdr_read(pipe_t pipe, void* buffer, size_t nbytes);
  * @param pipe The pipe to read
  * @param resbuf The result buffer
  * @param nbytes The minmum size of the buffer
- * @return The size of the buffer which contains the full typed header for this pipe
- *         If it's impossible to return such memory region, return 0 size and  NULL pointer
+ * @return The number of memory region has been pulled out either 1 or 0
  *         Error code indicates errors
  **/
-size_t pipe_hdr_get_buf(pipe_t pipe, size_t nbytes, void const** resbuf);
+int pipe_hdr_get_buf(pipe_t pipe, size_t nbytes, void const** resbuf);
 
 /**
  * @brief write the typed header to the pipe

--- a/lib/pservlet/include/pservlet/types.h
+++ b/lib/pservlet/include/pservlet/types.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2017, Hao Hou
+ * Copyright (C) 2017-2018, Hao Hou
  **/
 
 /**
@@ -83,6 +83,15 @@ typedef runtime_api_async_handle_t async_handle_t;
 
 /** @brief Get the module path that operates the given pipe */
 #define PIPE_CNTL_MODPATH  RUNTIME_API_PIPE_CNTL_OPCODE_MODPATH
+
+/** @brief Get the internal header buffer */
+#define PIPE_CNTL_GET_HDR_BUF RUNTIME_API_PIPE_CNTL_OPCODE_GET_HDR_BUF 
+
+/** @brief Get the internal data buffer */
+#define PIPE_CNTL_GET_DATA_BUF RUNTIME_API_PIPE_CNTL_OPCODE_GET_DATA_BUF
+
+/** @brief Release the exposed internal data buffer */
+#define PIPE_CNTL_PUT_DATA_BUF RUNTIME_API_PIPE_CNTL_OPCODE_PUT_DATA_BUF
 
 /** @brief no operation */
 #define PIPE_CNTL_NOP RUNTIME_API_PIPE_CNTL_OPCODE_NOP

--- a/lib/pservlet/pipe.c
+++ b/lib/pservlet/pipe.c
@@ -197,7 +197,7 @@ int pipe_data_get_buf(pipe_t pipe, size_t requested_size, void const** result, s
 
 	if(*result == NULL)
 	{
-		LOG_DEBUG("The pipe %x doesn't support PIPE_CNTL_GET_DATA_BUF operation");
+		LOG_DEBUG("The pipe %x doesn't support PIPE_CNTL_GET_DATA_BUF operation", pipe);
 		return 0;
 	}
 

--- a/lib/pservlet/pipe.c
+++ b/lib/pservlet/pipe.c
@@ -209,18 +209,16 @@ int pipe_data_release_buf(pipe_t pipe, void const* buffer, size_t actual_size)
 	return pipe_cntl(pipe, PIPE_CNTL_PUT_DATA_BUF, buffer, actual_size);
 }
 
-size_t pipe_hdr_get_buf(pipe_t pipe, size_t nbytes, void const** resbuf)
+int pipe_hdr_get_buf(pipe_t pipe, size_t nbytes, void const** resbuf)
 {
-	size_t rc = 0;
-
 	if(ERROR_CODE(int) == pipe_cntl(pipe, PIPE_CNTL_GET_HDR_BUF, nbytes, resbuf))
-		ERROR_RETURN_LOG(size_t, "Cannot get header buffer for the pipe");
+		ERROR_RETURN_LOG(int, "Cannot get header buffer for the pipe");
 
-	if(resbuf == NULL)
+	if(*resbuf == NULL)
 	{
 		LOG_DEBUG("Direct buffer access on pipe %x isn't possible", pipe);
 		return 0;
 	}
 
-	return rc;
+	return 1;
 }

--- a/lib/pstd/type.c
+++ b/lib/pstd/type.c
@@ -586,7 +586,7 @@ static inline int _ensure_header_read(pstd_type_instance_t* inst, pipe_t pipe, s
 	size_t bytes_can_read = typeinfo->used_size - buffer->valid_size;
 
 	/* First try to use direct buffer access */
-	if(buffer->valid_size == 0 && bytes_can_read > sizeof(void*))
+	if(buffer->valid_size == 0 && bytes_can_read >= sizeof(void*))
 	{
 		int rc = pipe_hdr_get_buf(pipe, bytes_can_read, (void const**)buffer->data);
 

--- a/src/itc/module.c
+++ b/src/itc/module.c
@@ -917,9 +917,9 @@ static inline int _get_data_body_buf(void const** result, size_t* min_size, size
 		return 0;
 	}
 
-	if(handle->expected_header_size > handle->processed_header_size)
+	if(handle->actual_header_size > handle->processed_header_size)
 	{
-		size_t bytes_to_ignore = handle->expected_header_size - handle->processed_header_size;
+		size_t bytes_to_ignore = handle->actual_header_size - handle->processed_header_size;
 
 		const void* skipped = NULL;
 


### PR DESCRIPTION
Of course, for the high performance mmap based file IO application, reducing the # of buffer copying is important. Thus we need readopt the idea about exposing the internal buffer (either memory buffer or mmapped file) to the application code. Which has been removed as read_inplace call previously. 

